### PR TITLE
fix: cut oid strings on correct length

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,9 +72,9 @@ proto.ref = function(name, follow) {
 
   for(var i = 0, len = refs.length; i < len; ++i) {
     if(refs[i].name === name) {
-      return follow && refs[i].symbolic ? 
+      return follow && refs[i].symbolic ?
         this.ref(refs[i].ref, true) :
-        refs[i] 
+        refs[i]
     }
   }
   return null
@@ -95,12 +95,12 @@ proto.refs = function(follow) {
     seen = []
     tmp = []
     for(var i = 0, len = out.length; i < len; ++i) {
-      if(seen.indexOf(out[i].hash) > -1) { 
+      if(seen.indexOf(out[i].hash) > -1) {
         continue
       }
       seen[seen.length] = out[i].hash
       tmp[tmp.length] = out[i]
-    }    
+    }
     out = tmp
   }
 
@@ -116,7 +116,7 @@ proto.raw = function(oid, ready) {
 function oidify(oid) {
   if(typeof oid === 'string') {
     var buf = new Buffer(20)
-    buf.write(oid, 0, 20, 'hex')
+    buf.write(oid.slice(0, 40), 0, 20, 'hex')
     oid = buf
   }
   return oid


### PR DESCRIPTION
Fixes a bug where a string like

```
be2be8ad4cc630bc3902149728907fcd0125ffa9        branch 'master' of remote
e100f6d598bacce657c612ce3ef1c943cdcc38a7    not-for-merge   branch 'somebranch' of remote
da35ea432f6f019bcc100ab518d47aa99398afd8    not-for-merge   branch 'somebranch' of remote
ce0bbdecaedcd28947c12ace2fbb39d07cfce7a8    not-for-merge   branch 'somebranch' of remote
d0801c8ea1bf0e06adbfb570d9a0030407749d37    not-for-merge   branch 'somebranch' of remote
a60724b348a1a9563404cfe4228ed55fd45aae8d    not-for-merge   branch 'somebranch' of remote
802b1c1d9a0a37c17039284010c6d9a74eb318bc    not-for-merge   branch 'somebranch' of remote
```

fed into oidify throws with:

```
buffer.js:586
        return this.hexWrite(string, offset, length);
                    ^

TypeError: Invalid hex string
    at TypeError (native)
    at Buffer.write (buffer.js:586:21)
    at oidify (~/node_modules/@marionebl/git-fs-repo/index.js:119:9)
    at Repository.proto.raw (~/node_modules/@marionebl/git-fs-repo/index.js:111:9)
    at Repository.proto._find (~/node_modules/@marionebl/git-fs-repo/index.js:59:8)
    at Repository.self.find (~/node_modules/@marionebl/git-fs-repo/index.js:51:17)
    at grab (~/node_modules/git-walk-refs/index.js:42:7)
    at step (~/node_modules/git-walk-refs/index.js:38:7)
    at nextTickCallbackWith0Args (node.js:453:9)
    at process._tickCallback (node.js:382:13)
```
